### PR TITLE
support commentout in Procfile

### DIFF
--- a/bin/proclet
+++ b/bin/proclet
@@ -117,6 +117,7 @@ sub load_procfile {
     my @services;
     open(my $fh, '<:utf8', $file) or die "cannot load procfile $file: $!";
     while (my $line = <$fh>) {
+        next if $line =~ /^#/;
         if (my ($name, $command) = ($line =~ /^([^:]+)\s*:\s*(.+)$/)) {
             push @services, [$name, $command];
         }

--- a/t/30proclet/01_basic.t
+++ b/t/30proclet/01_basic.t
@@ -37,9 +37,11 @@ while( <$fh> ) {
 close $fh;
 is( scalar keys %{$logok{w1}}, 1);
 is( scalar keys %{$logok{w2}}, 2);
+ok(!exists $logok{w3});
 
 is_deeply( [ uniq @{$port{w1}} ], [5000] );
 is_deeply( [ uniq sort @{$port{w2}} ], [5100,5101] );
+ok(!exists $port{w3});
 
 kill 'TERM', $pid;
 waitpid( $pid, 0);

--- a/t/30proclet/02_process.t
+++ b/t/30proclet/02_process.t
@@ -37,6 +37,7 @@ close $fh;
 ok(!exists $logok{w1});
 is( scalar keys %{$logok{w2}},2);
 is_deeply( [ uniq sort @{$port{w2}} ], [3100,3101] );
+ok(!exists $logok{w3});
 
 kill 'TERM', $pid;
 waitpid( $pid, 0);

--- a/t/30proclet/procfile/Procfile
+++ b/t/30proclet/procfile/Procfile
@@ -1,2 +1,3 @@
 w1: perl -e 'for(1..100){ open(my $fh, ">>:unix", $ENV{PROCLET_TESTFILE}) or die $!; print $fh "w1 $$ $ARGV[0]\n"; close $fh; sleep 1};' $PORT
 w2: perl -e 'for(1..100){ open(my $fh, ">>:unix", $ENV{PROCLET_TESTFILE}) or die $!; print $fh "w2 $$ $ARGV[0]\n"; close $fh; sleep 1};' $PORT
+#w3: perl -e 'for(1..100){ open(my $fh, ">>:unix", $ENV{PROCLET_TESTFILE}) or die $!; print $fh "w3 $$ $ARGV[0]\n"; close $fh; sleep 1};' $PORT


### PR DESCRIPTION
foreman だと https://github.com/ddollar/foreman/blob/master/lib/foreman/procfile.rb#L86 みたいな感じでコメントアウトが出来るのですが、 proclet だとそういう感じではなかったので足してみました。
ただ、foreman の正規表現に書き換えてしまうはちょっとあれだったので、先頭の # のみ考慮するようにしてみました。どうでしょうか。
